### PR TITLE
use slices not vectors

### DIFF
--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -10,7 +10,7 @@
 #' @useDynLib rscarbon, .registration = TRUE
 NULL
 
-rust_calibrate <- function(age, error, start, end, precision, path_to_calibration) .Call(wrap__rust_calibrate, age, error, start, end, precision, path_to_calibration)
+rust_calibrate <- function(age, error, start, end, precision, calbp, c14bp, tau) .Call(wrap__rust_calibrate, age, error, start, end, precision, calbp, c14bp, tau)
 
 
 # nolint end

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -190,27 +190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "dbgf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,12 +507,6 @@ checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "lazy_static"
@@ -1027,7 +1000,6 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 name = "rscarbon"
 version = "0.1.0"
 dependencies = [
- "csv",
  "extendr-api",
  "faer",
  "rand",
@@ -1054,12 +1026,6 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -5,11 +5,11 @@ version = '0.1.0'
 edition = '2021'
 
 [lib]
-crate-type = [ 'staticlib' ]
+crate-type = ['staticlib']
 name = 'rscarbon'
 
 [dependencies]
-csv = "1.3"
+# csv = "1.3"
 extendr-api = { git = "https://github.com/extendr/extendr.git" }
 faer = "0.19"
 rand = { version = "0.8", features = ["small_rng"] }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -1,4 +1,3 @@
-use csv::ReaderBuilder;
 use extendr_api::prelude::*;
 use faer::sparse::*;
 use rayon::prelude::*;
@@ -14,10 +13,7 @@ fn rust_calibrate(
     calbp: &[f64],
     c14bp: &[f64],
     tau: &[f64],
-    // path_to_calibration: &str,
 ) -> ExternalPtr<SparseColMat<usize, f64>> {
-    // let [calbp, c14bp, tau] = read_14c(path_to_calibration);
-
     let c14out: Vec<f64> = (start..end)
         .step_by(1)
         .rev()
@@ -33,28 +29,6 @@ fn rust_calibrate(
     );
 
     ExternalPtr::new(c14pd)
-}
-
-fn read_14c(path_to_calibration: &str) -> [Vec<f64>; 3] {
-    let mut rdr = ReaderBuilder::new()
-        .has_headers(false)
-        .comment(Some(b'#'))
-        .from_path(path_to_calibration)
-        .unwrap();
-
-    let mut calbp: Vec<f64> = Vec::new();
-    let mut c14bp: Vec<f64> = Vec::new();
-    let mut tau: Vec<f64> = Vec::new();
-
-    for result in rdr.records() {
-        let record = result.unwrap();
-
-        calbp.push(record[0].parse::<f64>().unwrap());
-        c14bp.push(record[1].parse::<f64>().unwrap());
-        tau.push(record[2].parse::<f64>().unwrap());
-    }
-
-    [calbp, c14bp, tau]
 }
 
 fn calibrate_bp14c(

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -2,7 +2,7 @@ use csv::ReaderBuilder;
 use extendr_api::prelude::*;
 use faer::sparse::*;
 use rayon::prelude::*;
-use statrs::distribution::{Normal, Continuous};
+use statrs::distribution::{Continuous, Normal};
 
 #[extendr]
 fn rust_calibrate(
@@ -11,10 +11,12 @@ fn rust_calibrate(
     start: i32,
     end: i32,
     precision: f64,
-    path_to_calibration: &str
+    calbp: &[f64],
+    c14bp: &[f64],
+    tau: &[f64],
+    // path_to_calibration: &str,
 ) -> ExternalPtr<SparseColMat<usize, f64>> {
-
-    let [calbp, c14bp, tau] = read_14c(path_to_calibration);
+    // let [calbp, c14bp, tau] = read_14c(path_to_calibration);
 
     let c14out: Vec<f64> = (start..end)
         .step_by(1)
@@ -23,19 +25,17 @@ fn rust_calibrate(
         .collect();
 
     let c14pd = calibrate_bp14c(
-        &age.to_vec(),
-        &error.to_vec(),
-        &interpolate_linear(&calbp, &c14bp, &c14out),
-        &interpolate_linear(&calbp, &tau, &c14out),
-        precision
+        &age,
+        &error,
+        &interpolate_linear(calbp, c14bp, &c14out),
+        &interpolate_linear(calbp, tau, &c14out),
+        precision,
     );
 
     ExternalPtr::new(c14pd)
-
 }
 
 fn read_14c(path_to_calibration: &str) -> [Vec<f64>; 3] {
-
     let mut rdr = ReaderBuilder::new()
         .has_headers(false)
         .comment(Some(b'#'))
@@ -47,93 +47,71 @@ fn read_14c(path_to_calibration: &str) -> [Vec<f64>; 3] {
     let mut tau: Vec<f64> = Vec::new();
 
     for result in rdr.records() {
-
         let record = result.unwrap();
 
         calbp.push(record[0].parse::<f64>().unwrap());
         c14bp.push(record[1].parse::<f64>().unwrap());
         tau.push(record[2].parse::<f64>().unwrap());
-
     }
 
     [calbp, c14bp, tau]
-
 }
 
 fn calibrate_bp14c(
-    age: &Vec<f64>,
-    error: &Vec<f64>,
-    mu: &Vec<f64>,
-    tau: &Vec<f64>,
-    precision: f64
+    age: &[f64],
+    error: &[f64],
+    mu: &[f64],
+    tau: &[f64],
+    precision: f64,
 ) -> SparseColMat<usize, f64> {
-
-    let res = age.into_par_iter()
+    let res = age
+        .into_par_iter()
         .zip(error.into_par_iter())
         .enumerate()
         .flat_map(|(i, (&s_mean, &s_error))| {
-
             mu.iter()
                 .zip(tau.iter())
                 .enumerate()
                 .filter_map(|(j, (&c_mean, &c_error))| {
-
-                    let n = Normal::new(
-                        c_mean,
-                        (s_error.powi(2i32) + c_error.powi(2i32)).sqrt()
-                    ).unwrap();
+                    let n = Normal::new(c_mean, (s_error.powi(2i32) + c_error.powi(2i32)).sqrt())
+                        .unwrap();
 
                     let d = n.pdf(s_mean);
 
                     if d < precision {
-
                         None
-
                     } else {
-
                         Some((i, j, d))
-
                     }
-
                 })
                 .collect::<Vec<(usize, usize, f64)>>()
-
         })
         .collect::<Vec<(usize, usize, f64)>>();
 
-    SparseColMat::<usize, f64>::try_new_from_triplets(
-        age.len(),
-        mu.len(),
-        &res
-    ).unwrap()
-
+    SparseColMat::<usize, f64>::try_new_from_triplets(age.len(), mu.len(), &res).unwrap()
 }
 
-fn interpolate_linear(x: &Vec<f64>, y: &Vec<f64>, xout: &Vec<f64>) -> Vec<f64> {
-
+fn interpolate_linear(x: &[f64], y: &[f64], xout: &[f64]) -> Vec<f64> {
     xout.iter()
         .map(|&xout| {
-
             let i = x.partition_point(|&y| y >= xout) - 1usize;
 
-            if xout == x[i] { return y[i] }
+            if xout == x[i] {
+                return y[i];
+            }
 
-            if xout == x[i+1] { return y[i+1] }
+            if xout == x[i + 1] {
+                return y[i + 1];
+            }
 
-            linear_model(x[i], x[i+1], y[i], y[i+1], xout)
-
+            linear_model(x[i], x[i + 1], y[i], y[i + 1], xout)
         })
         .collect()
-
 }
 
-fn linear_model(
-    x1: f64,
-    x2: f64,
-    y1: f64,
-    y2: f64,
-    xout: f64
-) -> f64 { y1 + (y2 - y1) * ((xout - x1) / (x2 - x1)) }
+fn linear_model(x1: f64, x2: f64, y1: f64, y2: f64, xout: f64) -> f64 {
+    y1 + (y2 - y1) * ((xout - x1) / (x2 - x1))
+}
 
 // Macro to generate exports.
 // This ensures exported functions are registered with R.


### PR DESCRIPTION
This is how I would consider rewriting this code. The `read_14c()` is unnecessary overhead for each time the function is ran. 

```r
calbs <- readr::read_csv(
  "https://raw.githubusercontent.com/ahb108/rcarbon/master/inst/extdata/intcal20.14c",
  skip = 11,
  col_select = 1:3,
  col_names = c("calbp", "c14bp", "tau"),
  col_types = "d"
)

library(dplyr)
library(rcarbon)

c14 <- emedyd |>
  as_tibble() |>
  rename_with(stringr::str_to_lower)

ages <- as.double(c14$cra)
errors <- as.double(c14$error)

bench::mark(
  rust_calibrate(
    ages,
    errors,
    55000,
    0,
    1e-5,
    calbs$calbp,
    calbs$c14bp,
    calbs$tau
  )
)
```