### PR TITLE
use r-package for data management

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 ^rscarbon\.Rproj$
 ^\.Rproj\.user$
 ^src/\.cargo$
+^data-raw$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,3 +12,6 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
 Config/rextendr/version: 0.3.1.9000
 SystemRequirements: Cargo (rustc package manager)
+Depends: 
+    R (>= 2.10)
+LazyData: true

--- a/R/calibrate.R
+++ b/R/calibrate.R
@@ -18,9 +18,23 @@ calibrate <- function(
   age,
   error,
   time_range = c(55000, 0),
-  precision = 1e-5,
-  calibration
+  calibration = "intcal20",
+  precision = 1e-5
 ){
+
+  all_calibrations <- c(
+    "intcal13", "intcal13nhpine16", "intcal20", "marine13", "marine20",
+    "normal", "shcal13", "shcal13shkauri16", "shcal20"
+  )
+
+  if (!calibration %in% all_calibrations) {
+
+    cli::cli_abort(
+      "{calibration} is not a recognized calibration curve.",
+      "i" = "Available curves include {all_calibrations}."
+    )
+
+  }
 
   rust_calibrate(
     age = as.numeric(age),
@@ -28,7 +42,7 @@ calibrate <- function(
     start = as.integer(time_range[2]),
     end = as.integer(time_range[1]),
     precision = as.numeric(precision),
-    calibration = calibration
+    calbs
   )
 
 }

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -12,5 +12,15 @@ NULL
 
 rust_calibrate <- function(age, error, start, end, precision, calbs) .Call(wrap__rust_calibrate, age, error, start, end, precision, calbs)
 
+Calibration <- new.env(parent = emptyenv())
+
+Calibration$read_14c <- function(path_to_calibration) .Call(wrap__Calibration__read_14c, path_to_calibration)
+
+#' @export
+`$.Calibration` <- function (self, name) { func <- Calibration[[name]]; environment(func) <- environment(); func }
+
+#' @export
+`[[.Calibration` <- `$.Calibration`
+
 
 # nolint end

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -10,17 +10,7 @@
 #' @useDynLib rscarbon, .registration = TRUE
 NULL
 
-rust_calibrate <- function(age, error, start, end, precision, calibration) .Call(wrap__rust_calibrate, age, error, start, end, precision, calibration)
-
-Calibration <- new.env(parent = emptyenv())
-
-Calibration$read_14c <- function(path_to_calibration) .Call(wrap__Calibration__read_14c, path_to_calibration)
-
-#' @export
-`$.Calibration` <- function (self, name) { func <- Calibration[[name]]; environment(func) <- environment(); func }
-
-#' @export
-`[[.Calibration` <- `$.Calibration`
+rust_calibrate <- function(age, error, start, end, precision, calbs) .Call(wrap__rust_calibrate, age, error, start, end, precision, calbs)
 
 
 # nolint end

--- a/data-raw/calbs.R
+++ b/data-raw/calbs.R
@@ -1,0 +1,13 @@
+## code to prepare `intcal20` dataset goes here
+
+library(readr)
+
+calbs <- readr::read_csv(
+  "https://raw.githubusercontent.com/ahb108/rcarbon/master/inst/extdata/intcal20.14c",
+  skip = 11,
+  col_select = 1:3,
+  col_names = c("calbp", "c14bp", "tau"),
+  col_types = "d"
+)
+
+usethis::use_data(calbs, overwrite = TRUE)

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -49,10 +49,11 @@ fn rust_calibrate(
     start: i32,
     end: i32,
     precision: f64,
-    calibration: &Calibration,
+    calbs: Dataframe<()>,
 ) -> ExternalPtr<SparseColMat<usize, f64>> {
-
-    let Calibration {calbp, c14bp, tau} = calibration;
+    let calbp: &[f64] = calbs.dollar("calbp").unwrap().try_into().unwrap();
+    let c14bp: &[f64] = calbs.dollar("c14bp").unwrap().try_into().unwrap();
+    let tau: &[f64] = calbs.dollar("tau").unwrap().try_into().unwrap();
 
     let c14out: Vec<f64> = (start..end)
         .step_by(1)

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -8,14 +8,12 @@ use statrs::distribution::{Continuous, Normal};
 struct Calibration {
     pub calbp: Vec<f64>,
     pub c14bp: Vec<f64>,
-    pub tau: Vec<f64>
+    pub tau: Vec<f64>,
 }
 
 #[extendr]
 impl Calibration {
-
     fn read_14c(path_to_calibration: &str) -> Self {
-
         let mut rdr = ReaderBuilder::new()
             .has_headers(false)
             .comment(Some(b'#'))
@@ -27,19 +25,15 @@ impl Calibration {
         let mut tau: Vec<f64> = Vec::new();
 
         for result in rdr.records() {
-
             let record = result.unwrap();
 
             calbp.push(record[0].parse::<f64>().unwrap());
             c14bp.push(record[1].parse::<f64>().unwrap());
             tau.push(record[2].parse::<f64>().unwrap());
-
         }
 
         Self { calbp, c14bp, tau }
-
     }
-
 }
 
 #[extendr]


### PR DESCRIPTION
* It is necessary to run  `Rscript data-raw/calbs.R` to generate the RDA file.
* The `calbs` data-frame is loaded lazily and part of the package
* no need for the `csv` crate yet (but it is still there)
* `Dataframe` from `extendr` likes to have a "row" `struct`, but passing `()` is fine here
* [ ] One _could_ use the `Dataframe` in the `Calibration` type, therefore I kept it.